### PR TITLE
fix: 修正辅助启动脚本

### DIFF
--- a/script/bin/ry.sh
+++ b/script/bin/ry.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 # ./ry.sh start 启动 stop 停止 restart 重启 status 状态
-AppName=ruoyi-admin.jar
+AppName=ruoyi-admin-wms.jar
 
 # JVM参数
 JVM_OPTS="-Dname=$AppName  -Duser.timezone=Asia/Shanghai -Xms512m -Xmx1024m -XX:MetaspaceSize=128m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -XX:+PrintGCDateStamps  -XX:+PrintGCDetails -XX:NewRatio=1 -XX:SurvivorRatio=30 -XX:+UseParallelGC -XX:+UseParallelOldGC"
@@ -26,7 +26,7 @@ function start()
     if [ x"$PID" != x"" ]; then
         echo "$AppName is running..."
     else
-        nohup java $JVM_OPTS -jar $AppName > /dev/null 2>&1 &
+        nohup java $JVM_OPTS -jar $AppName &> $LOG_PATH &
         echo "Start $AppName success..."
     fi
 }


### PR DESCRIPTION
Debian/Ubuntu的 /bin/sh 默认为dash，需指定bash否则不能使用函数和echo -e等高级功能
修正jar包名字
将日志记录到指定位置而不是丢弃